### PR TITLE
Add basic League use case

### DIFF
--- a/FutbolTracking.Api/FutbolTracking.Api.csproj
+++ b/FutbolTracking.Api/FutbolTracking.Api.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />-->
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.3.24172.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FutbolTracking.Api/Program.cs
+++ b/FutbolTracking.Api/Program.cs
@@ -1,8 +1,18 @@
+using FutbolTracking.Application.Contracts;
+using FutbolTracking.Application.Services;
+using FutbolTracking.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+var connectionString = builder.Configuration.GetConnectionString("Default");
+builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(connectionString));
+builder.Services.AddScoped<IApplicationDbContext>(sp => sp.GetRequiredService<ApplicationDbContext>());
+builder.Services.AddScoped<ILeagueService, LeagueService>();
 
 var app = builder.Build();
 
@@ -18,5 +28,11 @@ app.UseHttpsRedirection();
 // Sample endpoints for testing
 app.MapGet("/api/health", () => new { Status = "Healthy", Timestamp = DateTime.UtcNow })
     .WithName("GetHealth");
+
+app.MapPost("/api/leagues", async (AddLeagueRequest request, ILeagueService service, CancellationToken ct) =>
+{
+    var league = await service.AddLeagueAsync(request, ct);
+    return Results.Created($"/api/leagues/{league.Id}", league);
+}).WithName("AddLeague");
 
 app.Run();

--- a/FutbolTracking.Api/appsettings.json
+++ b/FutbolTracking.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "Default": "Data Source=(localdb)\\MSSQLLocalDB; Initial Catalog=Futbol; Integrated Security=True; Connect Timeout=30; Encrypt=False; Trust Server Certificate=False; Application Intent=ReadWrite; Multi-Subnet Failover=False"
+  }
 }

--- a/FutbolTracking.Application/Contracts/AddLeagueRequest.cs
+++ b/FutbolTracking.Application/Contracts/AddLeagueRequest.cs
@@ -1,0 +1,8 @@
+namespace FutbolTracking.Application.Contracts;
+
+public record AddLeagueRequest(
+    string Name,
+    string CountryKey,
+    string TypeKey,
+    string RankinKey,
+    Guid CreatedBy);

--- a/FutbolTracking.Application/Contracts/IApplicationDbContext.cs
+++ b/FutbolTracking.Application/Contracts/IApplicationDbContext.cs
@@ -1,0 +1,10 @@
+using FutbolTracking.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FutbolTracking.Application.Contracts;
+
+public interface IApplicationDbContext
+{
+    DbSet<League> Leagues { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/FutbolTracking.Application/Services/ILeagueService.cs
+++ b/FutbolTracking.Application/Services/ILeagueService.cs
@@ -1,0 +1,9 @@
+using FutbolTracking.Application.Contracts;
+using FutbolTracking.Domain.Entities;
+
+namespace FutbolTracking.Application.Services;
+
+public interface ILeagueService
+{
+    Task<League> AddLeagueAsync(AddLeagueRequest request, CancellationToken cancellationToken = default);
+}

--- a/FutbolTracking.Application/Services/LeagueService.cs
+++ b/FutbolTracking.Application/Services/LeagueService.cs
@@ -1,0 +1,37 @@
+using FutbolTracking.Application.Contracts;
+using FutbolTracking.Domain.Entities;
+using FutbolTracking.Domain.ValueObjects;
+
+namespace FutbolTracking.Application.Services;
+
+public class LeagueService : ILeagueService
+{
+    private readonly IApplicationDbContext _context;
+
+    public LeagueService(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<League> AddLeagueAsync(AddLeagueRequest request, CancellationToken cancellationToken = default)
+    {
+        var country = Country.List().First(c => c.Key.Equals(request.CountryKey, StringComparison.OrdinalIgnoreCase));
+        var type = LeagueType.List().First(t => t.Key.Equals(request.TypeKey, StringComparison.OrdinalIgnoreCase));
+        var rankin = Rankin.List().First(r => r.Key.Equals(request.RankinKey, StringComparison.OrdinalIgnoreCase));
+
+        var league = new League
+        {
+            Id = Guid.NewGuid(),
+            Name = request.Name,
+            Country = country,
+            Type = type,
+            Rankin = rankin,
+            CreatedOn = DateTime.UtcNow,
+            CreatedBy = request.CreatedBy
+        };
+
+        _context.Leagues.Add(league);
+        await _context.SaveChangesAsync(cancellationToken);
+        return league;
+    }
+}

--- a/FutbolTracking.Domain/Entities/BaseAuditableEntity.cs
+++ b/FutbolTracking.Domain/Entities/BaseAuditableEntity.cs
@@ -1,0 +1,11 @@
+namespace FutbolTracking.Domain.Entities;
+
+public abstract class BaseAuditableEntity
+{
+    public Guid Id { get; set; }
+    public bool IsEnabled { get; set; } = true;
+    public DateTime CreatedOn { get; set; }
+    public Guid CreatedBy { get; set; }
+    public DateTime? ModifiedOn { get; set; }
+    public Guid? ModifiedBy { get; set; }
+}

--- a/FutbolTracking.Domain/Entities/League.cs
+++ b/FutbolTracking.Domain/Entities/League.cs
@@ -1,0 +1,12 @@
+using FutbolTracking.Domain.ValueObjects;
+
+namespace FutbolTracking.Domain.Entities;
+
+public class League : BaseAuditableEntity
+{
+    public required string Name { get; set; }
+
+    public required Country Country { get; set; }
+    public required LeagueType Type { get; set; }
+    public required Rankin Rankin { get; set; }
+}

--- a/FutbolTracking.Domain/ValueObjects/Country.cs
+++ b/FutbolTracking.Domain/ValueObjects/Country.cs
@@ -1,0 +1,15 @@
+namespace FutbolTracking.Domain.ValueObjects;
+
+public record Country(Guid Id, string Key, string Value)
+{
+    public static readonly Country Spain = new(Guid.Parse("11111111-1111-1111-1111-111111111111"), "ESP", "Spain");
+    public static readonly Country Italy = new(Guid.Parse("22222222-2222-2222-2222-222222222222"), "ITA", "Italy");
+    public static readonly Country England = new(Guid.Parse("33333333-3333-3333-3333-333333333333"), "ENG", "England");
+    public static readonly Country France = new(Guid.Parse("44444444-4444-4444-4444-444444444444"), "FRA", "France");
+    public static readonly Country Portugal = new(Guid.Parse("55555555-5555-5555-5555-555555555555"), "POR", "Portugal");
+    public static readonly Country Netherlands = new(Guid.Parse("66666666-6666-6666-6666-666666666666"), "NED", "Netherlands");
+    public static readonly Country Argentina = new(Guid.Parse("77777777-7777-7777-7777-777777777777"), "ARG", "Argentina");
+    public static readonly Country Brazil = new(Guid.Parse("88888888-8888-8888-8888-888888888888"), "BRA", "Brazil");
+
+    public static IEnumerable<Country> List() => new[] { Spain, Italy, England, France, Portugal, Netherlands, Argentina, Brazil };
+}

--- a/FutbolTracking.Domain/ValueObjects/LeagueType.cs
+++ b/FutbolTracking.Domain/ValueObjects/LeagueType.cs
@@ -1,0 +1,9 @@
+namespace FutbolTracking.Domain.ValueObjects;
+
+public record LeagueType(Guid Id, string Key, string Value)
+{
+    public static readonly LeagueType Professional = new(Guid.Parse("99999999-9999-9999-9999-999999999999"), "PRO", "Professional");
+    public static readonly LeagueType Amateur = new(Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "AMT", "Amateur");
+
+    public static IEnumerable<LeagueType> List() => new[] { Professional, Amateur };
+}

--- a/FutbolTracking.Domain/ValueObjects/Rankin.cs
+++ b/FutbolTracking.Domain/ValueObjects/Rankin.cs
@@ -1,0 +1,11 @@
+namespace FutbolTracking.Domain.ValueObjects;
+
+public record Rankin(Guid Id, string Key, string Value)
+{
+    public static readonly Rankin Top = new(Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), "TOP", "Top");
+    public static readonly Rankin High = new(Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"), "HIG", "High");
+    public static readonly Rankin Medium = new(Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"), "MED", "Medium");
+    public static readonly Rankin Low = new(Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"), "LOW", "Low");
+
+    public static IEnumerable<Rankin> List() => new[] { Top, High, Medium, Low };
+}

--- a/FutbolTracking.Infrastructure/FutbolTracking.Infrastructure.csproj
+++ b/FutbolTracking.Infrastructure/FutbolTracking.Infrastructure.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.3.24172.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.3.24172.9" />
     <ProjectReference Include="..\FutbolTracking.Domain\FutbolTracking.Domain.csproj" />
   </ItemGroup>
 

--- a/FutbolTracking.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/FutbolTracking.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,0 +1,46 @@
+using FutbolTracking.Domain.Entities;
+using FutbolTracking.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+
+using FutbolTracking.Application.Contracts;
+
+namespace FutbolTracking.Infrastructure.Persistence;
+
+public class ApplicationDbContext : DbContext, IApplicationDbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<League> Leagues => Set<League>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<League>(builder =>
+        {
+            builder.HasKey(l => l.Id);
+            builder.Property(l => l.Name).IsRequired();
+            builder.OwnsOne(l => l.Country, b =>
+            {
+                b.Property(p => p.Id).HasColumnName("CountryId");
+                b.Property(p => p.Key).HasColumnName("CountryKey");
+                b.Property(p => p.Value).HasColumnName("CountryValue");
+            });
+            builder.OwnsOne(l => l.Type, b =>
+            {
+                b.Property(p => p.Id).HasColumnName("TypeId");
+                b.Property(p => p.Key).HasColumnName("TypeKey");
+                b.Property(p => p.Value).HasColumnName("TypeValue");
+            });
+            builder.OwnsOne(l => l.Rankin, b =>
+            {
+                b.Property(p => p.Id).HasColumnName("RankinId");
+                b.Property(p => p.Key).HasColumnName("RankinKey");
+                b.Property(p => p.Value).HasColumnName("RankinValue");
+            });
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add base entity model with audit fields
- add League entity and value objects for country, type, and rankin
- implement EF Core `ApplicationDbContext`
- create `AddLeagueRequest` and `LeagueService`
- configure dependency injection and new POST endpoint
- store connection string in appsettings

## Testing
- `dotnet test FutbolTracking.sln` *(fails: `bash: command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_6872b187c2848328904b6614f9091ca7